### PR TITLE
Feature request: add support for parameters in array reference

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1271,7 +1271,12 @@ function parse_vcat(ps::ParseState, ts::TokenStream, frst, closer)
             nxt = parse_eqs(ps, ts)
             continue
         elseif t === ';'
-            error("unexpected semicolon in array expression")
+            take_token(ts)
+            peek_token(ps, ts) === closer && continue
+            params = parse_arglist(ps, ts, closer)
+            unshift!(lst, Expr(:parameters, params...))
+            ex = Expr(:vcat); ex.args = push!(lst, nxt)
+            return ex
         elseif t === ']' || t === '}'
             error("unexpected \"$t\" in array expression")
         else


### PR DESCRIPTION
Hey @jakebolewski, @mlubin said that you spoke yesterday about adding support for `x[i,j;k,l]` syntax in Julia. Any chance you could offer some guidance on turning this into a PR for julia proper? I tried doing this myself about a month ago, but I couldn't quite overcome my inexperience with Scheme. Thanks!
