### PR TITLE
Fix most deprecations on julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.3-
 FactCheck
+Compat

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -706,7 +706,9 @@ end
 
 function next_token(ts::TokenStream, whitespace_newline::Bool)
     ts.ateof && return EOF
-    ts.isspace = skipws(ts, whitespace_newline)
+    tmp = skipws(ts, whitespace_newline)
+    tmp == EOF && return EOF
+    ts.isspace = tmp
     while !eof(ts.io)
         c = peekchar(ts)
         if eof(c)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,6 +1,7 @@
 # Julia Source Parser
 module Parser
 
+using Compat
 using ..Lexer
 
 export parse
@@ -1789,7 +1790,7 @@ function _parse_atom(ps::ParseState, ts::TokenStream)
                 if isa(call, Expr) && call.head === :call
                     nargs = length(call.args)
                     ex = Expr(:macrocall, macroify_name(call.args[1]))
-                    Base.sizehint(ex.args, nargs)
+                    Base.sizehint!(ex.args, nargs)
                     for i = 2:nargs
                         push!(ex.args, call.args[i])
                     end

--- a/test/ast.jl
+++ b/test/ast.jl
@@ -1,5 +1,5 @@
 norm_ast(ex::Expr) = begin
-    args = {}
+    args = Any[]
     for a in ex.args
         if isa(a, Expr)
             if a.head === :line

--- a/test/lexer.jl
+++ b/test/lexer.jl
@@ -683,7 +683,7 @@ facts("test skip ws and comment") do
 end
 
 tokens(ts::TokenStream) = begin
-    toks = {}
+    toks = Any[]
     while !eof(ts.io)
         push!(toks, Lexer.next_token(ts))
     end
@@ -705,7 +705,7 @@ end
 facts("test set_token! / last_token") do
     code = "1 + 1"
     tks = tokens(code) 
-    @fact tks => {1, :+, 1} 
+    @fact tks => Any[1, :+, 1]
     
     ts = TokenStream(code)
     @fact Lexer.last_token(ts) => nothing
@@ -770,55 +770,55 @@ facts("test next_token") do
     @fact tok => '\n'
 
     toks = tokens("true false")
-    @fact toks => {true, false}
+    @fact toks => Any[true, false]
 
     toks = tokens("(test,)")
-    @fact toks => {'(', :test, ',', ')'}
+    @fact toks => Any['(', :test, ',', ')']
 
     toks = tokens("[10.0,2.0]")
-    @fact toks => {'[', 10.0, ',', 2.0, ']'}
+    @fact toks => Any['[', 10.0, ',', 2.0, ']']
 
     toks = tokens("#test\n{10,};")
-    @fact toks => {'\n', '{', 10, ',', '}', ';'}
+    @fact toks => Any['\n', '{', 10, ',', '}', ';']
 
     toks = tokens("#=test1\ntest2\n=#@test\n")
-    @fact toks => {'@', :test, '\n'}
+    @fact toks => Any['@', :test, '\n']
 
     toks = tokens("1<=2")
-    @fact toks => {1, :(<=), 2}
+    @fact toks => Any[1, :(<=), 2]
 
     toks = tokens("1.0 .+ 2")
-    @fact toks => {1.0, :(.+), 2}
+    @fact toks => Any[1.0, :(.+), 2]
 
     toks = tokens("abc .+ .1")
-    @fact toks => {:abc, :(.+), 0.1}
+    @fact toks => Any[:abc, :(.+), 0.1]
 
     toks = tokens("`ls`")
-    @fact toks => {'`', :ls, '`'}
+    @fact toks => Any['`', :ls, '`']
 
     toks = tokens("@testmacro")
-    @fact toks => {'@', :testmacro}
+    @fact toks => Any['@', :testmacro]
 
     toks = tokens("x::Int32 + 1")
-    @fact toks => {:x, :(::), :Int32, :(+), 1}
+    @fact toks => Any[:x, :(::), :Int32, :(+), 1]
 
     toks = tokens("func(2) |> send!")
-    @fact toks => {:func, '(', 2, ')', :(|>), :(send!)}
+    @fact toks => Any[:func, '(', 2, ')', :(|>), :(send!)]
 
     sym_end = symbol("end")
     
     toks = tokens("type Test{T<:Int32}\n\ta::T\n\tb::T\nend")
-    @fact toks => {:type, :Test, '{',  :T, :(<:), :Int32, '}', '\n',
+    @fact toks => Any[:type, :Test, '{',  :T, :(<:), :Int32, '}', '\n',
                    :a, :(::), :T, '\n', 
                    :b, :(::), :T, '\n', 
-                   sym_end} 
+                   sym_end]
 
     toks = tokens("function(x::Int)\n\treturn x^2\nend")
-    @fact toks => {:function, '(', :x, :(::), :Int, ')', '\n',
+    @fact toks => Any[:function, '(', :x, :(::), :Int, ')', '\n',
                    :return , :x, :(^), 2, '\n',
-                   sym_end}
+                   sym_end]
 
     toks = tokens("+(x::Bool, y::Bool) = int(x) + int(y)")
-    @fact toks => {:+, '(', :x, :(::), :Bool, ',', :y, :(::), :Bool, ')',
-                   :(=), :int, '(', :x, ')', :+, :int, '(', :y, ')'}
+    @fact toks => Any[:+, '(', :x, :(::), :Bool, ',', :y, :(::), :Bool, ')',
+                   :(=), :int, '(', :x, ')', :+, :int, '(', :y, ')']
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -235,7 +235,7 @@ facts("test prefixed string literals") do
 end
 
 facts("test cell expressions") do
-    exprs = [
+    exprs = VERSION < v"0.4.0-dev" ? [
         "{}",
         "{1,2}",
         "{1 2 3}",
@@ -246,6 +246,17 @@ facts("test cell expressions") do
             {1,2,3}}""",
         "{:a => 1,'b' => 2}",
         "{i for i=1:10}",
+    ] : [
+        "[]",
+        "Any[1,2]",
+        "Any[1 2 3]",
+        "Any[1;2;3]",
+        "Any[Any[1 2 3], Any[1 2 3]]",
+        "Any[Any[1,2,3] Any[1,2,3,]]",
+        """Any[Any[1,2,3]
+            Any[1,2,3]]""",
+        "Any[:a => 1,'b' => 2]",
+        "Any[i for i=1:10]",
     ]
     for ex in exprs
         @fact (Parser.parse(ex) |> norm_ast) => (Base.parse(ex) |> norm_ast)
@@ -262,7 +273,7 @@ facts("test cat expressions") do
         "[[1,2,3] [1,2,3,]]",
         """[[1,2,3]
             [1,2,3]]""",
-        "[:a => 1, :b => 2]",
+        VERSION < v"0.4.0-dev+980" ? "[:a => 1, :b => 2]" : "Dict(:a => 1, :b => 2)",
         "[i for i=1:10]"
     ]
     for ex in exprs


### PR DESCRIPTION
This fixes the large majority of deprecation warnings on julia 0.4 (there are still a few when parsing base/test, but I couldn't quite follow where they were coming from).

Note, however, that there are a significant number of test failures, and I didn't fix those.
