### PR TITLE
WIP: Fix import breakage due to JuliaLang/julia#11333

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1077,12 +1077,10 @@ function parse_imports(ps::ParseState, ts::TokenStream, word::Symbol)
     if from || nt === ','
         take_token(ts)
         done = false
-    elseif nt in ('\n', ';')
-        done = true
-    elseif Lexer.eof(nt)
-        done = true
-    else
+    elseif nt === '.'
         done = false
+    else
+        done = true
     end
     rest = done? Any[] : parse_comma_sep(ps, ts, (ps, ts) -> parse_import(ps, ts, word))
     if from
@@ -1139,15 +1137,9 @@ function parse_import(ps::ParseState, ts::TokenStream, word::Symbol)
         if nc === '.'
             Lexer.takechar(ts)
             push!(path, macrocall_to_atsym(parse_atom(ps, ts)))
-            continue
-        end
-        nt = peek_token(ps, ts)
-        if (Lexer.eof(nt) ||
-            (isa(nt, CharSymbol) && (nt === '\n' || nt === ';' || nt === ',' || nt === :(:))))
+        else
             ex = Expr(word); ex.args = path
             return ex
-        else
-            throw(ParseError("invalid \"$word\" statement"))
         end
     end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -695,6 +695,14 @@ facts("test import / using / importall expressions") do
         """import Test.Base: @a, b, c, d""",
         """using Test""",
         """importall Test""",
+        """:(using A)""",
+        """:(using A.b, B)""",
+        """:(using A: b, c.d)""",
+        """:(importall A)""",
+        """:(import A)""",
+        """:(import A.b, B)""",
+        """:(import A: b, c.d)""",
+        """begin using A end"""
     ]
     for ex in exprs
         @fact Parser.parse(ex) --> Base.parse(ex)


### PR DESCRIPTION
This PR is an attempt to fix the import breakage discussed in #19. Specifically, it causes `import`/`using` statements to be parsed in accordance to JuliaLang/julia#11333, i.e. a newline or `;` is no longer required to terminate the statement.

All added tests pass locally, and no additional failures have occurred, except for the test for parsing `"begin using A end"`. However, I can't seem reproduce this failure outside the scope of the specific test:

```julia

# Called from ~/.julia/JuliaParser/test, on the fix-import branch.
# There were 21 tests failing on master already, so below 
# I'll just skip to the failure that this PR currently adds.
julia> include("runtests.jl") 
⋮
test import / using / importall expressions
  Failure   :: (line:442) :: Expected: begin  # none, line 1:
    using A
end => begin  # /Users/jarrettrevels/.julia/JuliaParser/test/parser.jl, line 1:
    using A
end
    Parser.parse(ex) --> Base.parse(ex)
Out of 24 total facts:
  Verified: 23
  Failed:   1
⋮
ERROR: LoadError: FactCheck finished with 22 non-successful tests. 
 in error at ./error.jl:21
 in exitstatus at /Users/jarrettrevels/.julia/FactCheck/src/FactCheck.jl:500
 in include at ./boot.jl:254
 in include_from_node1 at ./loading.jl:197
while loading /Users/jarrettrevels/.julia/JuliaParser/test/runtests.jl, in expression starting on line 8

julia> ex = """begin using A end""" # the erroring statement
"begin using A end"

julia> Parser.parse(ex) == Base.parse(ex) # somehow works?
true
```