### PR TITLE
fixed error 'cannot resize array with shared data' in julia 0.4.0

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -362,11 +362,11 @@ function read_operator(ts::TokenStream, c::Char)
         return symbol(c)
     end
     str, c = [c], nc
-    opsym  = symbol(utf32(str))
+    opsym  = symbol(utf32(copy(str)))
     while true
         if !eof(c) && is_opchar(c)
             push!(str, c)
-            newop = symbol(utf32(str))
+            newop = symbol(utf32(copy(str)))
             if is_operator(newop)
                 skip(ts, utf8sizeof(c))
                 c, opsym = peekchar(ts), newop


### PR DESCRIPTION
In Julia 0.4.0 it seems that char arrays are shared and reused, so this error keeps happening in LightTable, which relies on JuliaParser:

```
WARNING: LightTable.jl: cannot resize array with shared data
 in push! at ./array.jl:433
 in read_operator at /home/james/.julia/v0.4/JuliaParser/src/lexer.jl:368
 in next_token at /home/james/.julia/v0.4/JuliaParser/src/lexer.jl:752
 in qualifiedname at /home/james/.julia/v0.4/Jewel/src/parse/scope.jl:59
 in nexttoken at /home/james/.julia/v0.4/Jewel/src/parse/scope.jl:78
 in nextscope! at /home/james/.julia/v0.4/Jewel/src/parse/scope.jl:116
 in scopes at /home/james/.julia/v0.4/Jewel/src/parse/scope.jl:149
 [inlined code] from /home/james/.julia/v0.4/Lazy/src/macros.jl:141
 in codemodule at /home/james/.julia/v0.4/Jewel/src/parse/parse.jl:8
 in getmodule at /home/james/.julia/v0.4/Jewel/src/eval.jl:42
 in anonymous at /home/james/.julia/v0.4/Jewel/src/LightTable/completions.jl:4
 in handlecmd at /home/james/.julia/v0.4/Jewel/src/LightTable/LightTable.jl:70
 in handlenext at /home/james/.julia/v0.4/Jewel/src/LightTable/LightTable.jl:86
 in server at /home/james/.julia/v0.4/Jewel/src/LightTable/LightTable.jl:27
 in server at /home/james/.julia/v0.4/Jewel/src/Jewel.jl:23
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in process_options at ./client.jl:308
 in _start at ./client.jl:411
```

Copying the array before converting it to utf32 fixes the problem. You can duplicate this problem by trying to lex the code:
```Julia
val = 1
val += 1
val = 1
```

ie just call `Lexer.next_token(ts, true)` on it until you get the error.

By the way, I only made the fix to the calls to `utf32()` that were immediately affecting me. I think this may need to be applied everywhere in the codebase.



